### PR TITLE
added alpha and beta params for beta-binomial

### DIFF
--- a/kcbo/statistical_tests/beta_binomial_difference.py
+++ b/kcbo/statistical_tests/beta_binomial_difference.py
@@ -11,7 +11,7 @@ class BetaBinomialTest(StatisticalTest):
     def __init__(self, *args, **kwargs):
         super(type(self), self).__init__(*args, **kwargs)
 
-    def initialize_test(self, dataframe, groups=None, groupcol='group', successcol='successes', totalcol='total', samples=100000, **kwargs):
+    def initialize_test(self, dataframe, groups=None, groupcol='group', successcol='successes', totalcol='total', samples=100000, alpha_ = 1., beta_ = 1., **kwargs):
         df = dataframe
         self.df = df
 
@@ -22,6 +22,8 @@ class BetaBinomialTest(StatisticalTest):
         self.successcol = successcol
         self.totalcol = totalcol
         self.samples = samples
+        self.alpha_ = alpha_
+        self.beta_ = beta_
 
         self.keys = list(combinations(groups, 2))
         self.distributions = {}
@@ -37,7 +39,7 @@ class BetaBinomialTest(StatisticalTest):
             successes = group_data[self.successcol]
 
             mc_data = beta.rvs(
-                successes + 1., total - successes + 1., size=samples)
+                successes + self.alpha_, total - successes + self.beta_, size=samples)
             self.distributions[group] = mc_data
 
     @statistic('difference', is_distribution=True, is_estimate=True, pairwise=True)
@@ -105,7 +107,7 @@ class BetaBinomialTest(StatisticalTest):
 
         return description
 
-def conversion_test(dataframe, groups=None, groupcol='group', successcol='conversions', totalcol='total', samples=100000, **kwargs):
+def conversion_test(dataframe, groups=None, groupcol='group', successcol='conversions', totalcol='total', samples=100000, alpha_ = 1., beta_ = 1., **kwargs):
     """Beta-Binomial model Conversion t_test.py
 
     Given a dataframe of the form:
@@ -132,4 +134,4 @@ def conversion_test(dataframe, groups=None, groupcol='group', successcol='conver
     raw_data: dictionary of output data
 
     """
-    return BetaBinomialTest(dataframe, groups, groupcol, successcol, totalcol, samples, **kwargs).summary()
+    return BetaBinomialTest(dataframe, groups, groupcol, successcol, totalcol, samples, alpha_, beta_, **kwargs).summary()


### PR DESCRIPTION
Added alpha and beta as parameters for beta-binomial.  It's useful in display advertising to vary this parameter due to the extremely low conversion rates (using beta 2,2 for example for something more related to bernoulli trial). 

I'm a horrible production code writer so feel free to suggest changes to my code in the pull request =)

I tested this with varying the parameters for two highly imbalanced groups (90%/10% a/b test) with 0.01% ctr rates and the parameters behave as expected.
